### PR TITLE
Add unit tests for hudson.cli.HexDump

### DIFF
--- a/cli/src/test/java/hudson/cli/HexDumpTest.java
+++ b/cli/src/test/java/hudson/cli/HexDumpTest.java
@@ -8,30 +8,30 @@ public class HexDumpTest {
   @Test
   public void testToHex1() {
     Assert.assertEquals("'fooBar'",
-            HexDump.toHex("fooBar".getBytes()));
-    Assert.assertEquals("0xc3 0x83",
-            HexDump.toHex("Ã".getBytes()));
-    Assert.assertEquals("0xe2 0x82 0xac '100'",
-            HexDump.toHex("€100".getBytes()));
-    Assert.assertEquals("'1' 0xc3 0xb7 '2'",
-            HexDump.toHex("1÷2".getBytes()));
+            HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}));
+    Assert.assertEquals("0xc3",
+            HexDump.toHex(new byte[] {(byte)'Ã'}));
+    Assert.assertEquals("0xac '100'",
+            HexDump.toHex(new byte[] {(byte)'€', '1', '0', '0'}));
+    Assert.assertEquals("'1' 0xf7 '2'",
+            HexDump.toHex(new byte[] {'1', (byte)'÷', '2'}));
     Assert.assertEquals("'foo' 0x0a\n'Bar'",
-            HexDump.toHex("foo\nBar".getBytes()));
+            HexDump.toHex(new byte[] {'f', 'o', 'o', '\n', 'B', 'a', 'r'}));
   }
 
   @Test
   public void testToHex2() {
     Assert.assertEquals("'ooBa'",
-            HexDump.toHex("fooBar".getBytes(), 1, 4));
-    Assert.assertEquals("0xc3 0x83",
-            HexDump.toHex("Ã".getBytes(), 0, 2));
-    Assert.assertEquals("0xe2 0x82 0xac '10'",
-            HexDump.toHex("€100".getBytes(), 0, 5));
-    Assert.assertEquals("0xc3 0xb7",
-            HexDump.toHex("1÷2".getBytes(), 1, 2));
+            HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}, 1, 4));
+    Assert.assertEquals("0xc3",
+            HexDump.toHex(new byte[] {(byte)'Ã'}, 0, 1));
+    Assert.assertEquals("0xac '10'",
+            HexDump.toHex(new byte[] {(byte)'€', '1', '0', '0'}, 0, 3));
+    Assert.assertEquals("0xf7 '2'",
+            HexDump.toHex(new byte[] {'1', (byte)'÷', '2'}, 1, 2));
     Assert.assertEquals("'Bar'",
-            HexDump.toHex("foo\nBar".getBytes(), 4, 3));
+            HexDump.toHex(new byte[] {'f', 'o', 'o', '\n', 'B', 'a', 'r'}, 4, 3));
     Assert.assertEquals("",
-            HexDump.toHex("fooBar".getBytes(), 0, 0));
+            HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}, 0, 0));
   }
 }

--- a/cli/src/test/java/hudson/cli/HexDumpTest.java
+++ b/cli/src/test/java/hudson/cli/HexDumpTest.java
@@ -1,0 +1,37 @@
+package hudson.cli;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HexDumpTest {
+
+  @Test
+  public void testToHex1() {
+    Assert.assertEquals("'fooBar'",
+            HexDump.toHex("fooBar".getBytes()));
+    Assert.assertEquals("0xc3 0x83",
+            HexDump.toHex("Ã".getBytes()));
+    Assert.assertEquals("0xe2 0x82 0xac '100'",
+            HexDump.toHex("€100".getBytes()));
+    Assert.assertEquals("'1' 0xc3 0xb7 '2'",
+            HexDump.toHex("1÷2".getBytes()));
+    Assert.assertEquals("'foo' 0x0a\n'Bar'",
+            HexDump.toHex("foo\nBar".getBytes()));
+  }
+
+  @Test
+  public void testToHex2() {
+    Assert.assertEquals("'ooBa'",
+            HexDump.toHex("fooBar".getBytes(), 1, 4));
+    Assert.assertEquals("0xc3 0x83",
+            HexDump.toHex("Ã".getBytes(), 0, 2));
+    Assert.assertEquals("0xe2 0x82 0xac '10'",
+            HexDump.toHex("€100".getBytes(), 0, 5));
+    Assert.assertEquals("0xc3 0xb7",
+            HexDump.toHex("1÷2".getBytes(), 1, 2));
+    Assert.assertEquals("'Bar'",
+            HexDump.toHex("foo\nBar".getBytes(), 4, 3));
+    Assert.assertEquals("",
+            HexDump.toHex("fooBar".getBytes(), 0, 0));
+  }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `hudson.cli.HexDump` in the `jenkins-parent` module is not fully tested.

I've written some tests that cover this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.